### PR TITLE
Outpath extractcube

### DIFF
--- a/scripts/buildcal
+++ b/scripts/buildcal
@@ -164,7 +164,7 @@ def buildcalibrations(inImage, inLam, mask, indir, outdir="./",
                                        bounds_error=False, fill_value='extrapolate')
             fullsigarr[i, j] = fit(psftool.lam_indx[i, j])
     out = fits.HDUList(fits.PrimaryHDU(fullsigarr.astype(np.float32)))
-    out.writeto('PSFwidths.fits', overwrite=True)
+    out.writeto( outdir + 'PSFwidths.fits', overwrite=True)
 
     #################################################################
     # Wavelengths at which to return the PSFlet templates
@@ -262,7 +262,7 @@ def buildcalibrations(inImage, inLam, mask, indir, outdir="./",
 
 
 
-def main(infilelist, bgfiles, band, lam, upsample, nthreads):
+def main(infilelist, bgfiles, band, lam, upsample, nthreads, outdir="./"):
     
     """
     Top-level task to run buildcal from the python environment. When called from the command line, passes input (after 
@@ -282,6 +282,11 @@ def main(infilelist, bgfiles, band, lam, upsample, nthreads):
                     desired (True) or not (False).
     6. nthreads:    Number of threads for multithreading. Should be no
                     more than multiprocessing.cpu_count().
+    
+    Optional inputs:
+    1. outdir:   directory in which to place generated files. Default is
+                 the current working directory.
+        
 
     Returns None, writes calibration files to outdir.
     
@@ -295,7 +300,12 @@ def main(infilelist, bgfiles, band, lam, upsample, nthreads):
     >>> buildcal = imp.load_source('buildcal', '/path/to/charis-dep/scripts/buildcal' )
 
     """
-
+    ###############################################################
+    # Check if outdir ends in / ; if not, adds /
+    ###############################################################
+    
+    if not outdir.endswith('/') and outdir != '' :
+        outdir += '/'
     
     ###############################################################
     # Wavelength limits in nm
@@ -365,7 +375,7 @@ def main(infilelist, bgfiles, band, lam, upsample, nthreads):
         ibg += 1
     if len(bgfiles) > 0:
         background = Image(data=num / denom, ivar=1. / denom)
-        background.write('background.fits')
+        background.write( outdir + 'background.fits')
     else:
         hdr['bkgnd001'] = ('None', 'Dark(s) used for background subtraction')
 
@@ -385,15 +395,15 @@ def main(infilelist, bgfiles, band, lam, upsample, nthreads):
 
     buildcalibrations(inImage, lam, mask, indir, lam1=lam1, lam2=lam2,
                       upsample=upsample, R=R, order=3, trans=trans,
-                      header=hdr, ncpus=nthreads)
+                      header=hdr, ncpus=nthreads, outdir=outdir)
 
     out = fits.HDUList(fits.PrimaryHDU(None, hdr))
-    out.writeto('cal_params.fits', overwrite=True)
+    out.writeto( outdir + 'cal_params.fits', overwrite=True)
 
-    shutil.copy(os.path.join(indir, 'lensletflat.fits'), './lensletflat.fits')
+    shutil.copy(os.path.join(indir, 'lensletflat.fits'), outdir + 'lensletflat.fits')
 
     for filename in ['mask.fits', 'pixelflat.fits']:
-        shutil.copy(os.path.join(indir, filename), './' + filename)
+        shutil.copy(os.path.join(indir, filename), outdir + filename)
 
 
 

--- a/scripts/buildcal
+++ b/scripts/buildcal
@@ -259,6 +259,146 @@ def buildcalibrations(inImage, inLam, mask, indir, outdir="./",
     return None
 
 
+
+
+
+def main(infilelist, bgfiles, band, lam, upsample, nthreads):
+    
+    """
+    Top-level task to run buildcal from the python environment. When called from the command line, passes input (after 
+    parsing) to this function.
+
+    Inputs:
+    1. infilelist:  List of file paths and names to the LASER flat files.
+    2. bgfiles:     List of file paths and names to the corresponding 
+                    DARK files, if desired. To run without dark files, 
+                    set this as None or an empty list, [].
+    3. band:        Name of the filter used; one of 'J', 'H', 'K', or
+                    'lowres'.
+    4. lam:         Integer indicating the wavelength in nm, calculated by
+                    the OBJECT keyword in the laser image(s) header; one
+                    of 1200, 1550, or 2346.
+    5. upsample:    True/False boolean indicating whether upsampling is
+                    desired (True) or not (False).
+    6. nthreads:    Number of threads for multithreading. Should be no
+                    more than multiprocessing.cpu_count().
+
+    Returns None, writes calibration files to outdir.
+    
+    If importing into Python for direct use or automation, recommend using pyximport (for Cython handling) and importing
+    module via imp.load_source. Eg:
+    
+    >>> import pyximport
+    >>> pyximport.install(language_level=2)
+    (None, <pyximport.pyximport.PyxImporter object at 0x10bac3d50>)
+    >>> import imp
+    >>> buildcal = imp.load_source('buildcal', '/path/to/charis-dep/scripts/buildcal' )
+
+    """
+
+    
+    ###############################################################
+    # Wavelength limits in nm
+    ###############################################################
+
+    if band == 'J':
+        lam1, lam2 = [1155, 1340]
+    elif band == 'H':
+        lam1, lam2 = [1470, 1800]
+    elif band == 'K':
+        lam1, lam2 = [2005, 2380]
+    elif band == 'lowres':
+        lam1, lam2 = [1140, 2410]
+    else:
+        raise ValueError('Band must be one of: J, H, K, lowres')
+
+    if lam < lam1 or lam > lam2:
+        raise ValueError("Error: wavelength " + str(lam) + " outside range (" +
+                         str(lam1) + ", " + str(lam2) + ") of mode " + band)
+
+    #prefix = os.path.dirname(os.path.realpath(__file__))
+    prefix = pkg_resources.resource_filename('charis', 'calibrations')
+
+    ###############################################################
+    # Spectral resolutions for the final calibration files
+    ###############################################################
+
+    if band in ['J', 'H', 'K']:
+        indir = os.path.join(prefix, "highres_" + band)
+        R = 100
+    else:
+        indir = os.path.join(prefix, "lowres")
+        R = 30
+
+    mask = fits.open(os.path.join(indir, 'mask.fits'))[0].data
+
+    hdr = fits.PrimaryHDU().header
+    hdr.clear()
+    # infilelist = glob.glob(infile)            # Moved to arg processing when called from terminal; otherwise provided
+    if len(infilelist) == 0:
+        raise ValueError("No CHARIS file found for calibration.")
+
+    hdr['calfname'] = (re.sub('.*/', '', infilelist[0]),
+                       'Monochromatic image used for calibration')
+    try:
+        hdr['cal_date'] = (fits.open(infilelist[0])[0].header['mjd'],
+                           'MJD date of calibration image')
+    except:
+        hdr['cal_date'] = ('unavailable', 'MJD date of calibration image')
+    hdr['cal_lam'] = (lam, 'Wavelength of calibration image (nm)')
+    hdr['cal_band'] = (band, 'Band/mode of calibration image (J/H/K/lowres)')
+
+    ###############################################################
+    # Mean background count rate, weighted by inverse variance
+    ###############################################################
+
+    print('Computing ramps from sequences of raw reads')
+    num = 0
+    denom = 1e-100
+    ibg = 1
+    for filename in bgfiles:
+        bg = utr.calcramp(filename=filename, mask=mask, maxcpus=nthreads)
+        num = num + bg.data * bg.ivar
+        denom = denom + bg.ivar
+        hdr['bkgnd%03d' % (ibg)] = (re.sub('.*/', '', filename),
+                                    'Dark(s) used for background subtraction')
+        ibg += 1
+    if len(bgfiles) > 0:
+        background = Image(data=num / denom, ivar=1. / denom)
+        background.write('background.fits')
+    else:
+        hdr['bkgnd001'] = ('None', 'Dark(s) used for background subtraction')
+
+    ###############################################################
+    # Monochromatic flatfield image
+    ###############################################################
+
+    num = 0
+    denom = 1e-100
+    for filename in infilelist:
+        im = utr.calcramp(filename=filename, mask=mask, maxcpus=nthreads)
+        num = num + im.data * im.ivar
+        denom = denom + im.ivar
+    inImage = Image(data=num / denom, ivar=mask * 1. / denom)
+
+    trans = np.loadtxt(os.path.join(indir, band + '_tottrans.dat'))
+
+    buildcalibrations(inImage, lam, mask, indir, lam1=lam1, lam2=lam2,
+                      upsample=upsample, R=R, order=3, trans=trans,
+                      header=hdr, ncpus=nthreads)
+
+    out = fits.HDUList(fits.PrimaryHDU(None, hdr))
+    out.writeto('cal_params.fits', overwrite=True)
+
+    shutil.copy(os.path.join(indir, 'lensletflat.fits'), './lensletflat.fits')
+
+    for filename in ['mask.fits', 'pixelflat.fits']:
+        shutil.copy(os.path.join(indir, filename), './' + filename)
+
+
+
+
+
 if __name__ == "__main__":
 
     if len(sys.argv) < 2:
@@ -377,101 +517,8 @@ if __name__ == "__main__":
             exit()
         else:
             print("Invalid input.")
-
-    ###############################################################
-    # Wavelength limits in nm
-    ###############################################################
-
-    if band == 'J':
-        lam1, lam2 = [1155, 1340]
-    elif band == 'H':
-        lam1, lam2 = [1470, 1800]
-    elif band == 'K':
-        lam1, lam2 = [2005, 2380]
-    elif band == 'lowres':
-        lam1, lam2 = [1140, 2410]
-    else:
-        raise ValueError('Band must be one of: J, H, K, lowres')
-
-    if lam < lam1 or lam > lam2:
-        raise ValueError("Error: wavelength " + str(lam) + " outside range (" +
-                         str(lam1) + ", " + str(lam2) + ") of mode " + band)
-
-    #prefix = os.path.dirname(os.path.realpath(__file__))
-    prefix = pkg_resources.resource_filename('charis', 'calibrations')
-
-    ###############################################################
-    # Spectral resolutions for the final calibration files
-    ###############################################################
-
-    if band in ['J', 'H', 'K']:
-        indir = os.path.join(prefix, "highres_" + band)
-        R = 100
-    else:
-        indir = os.path.join(prefix, "lowres")
-        R = 30
-
-    mask = fits.open(os.path.join(indir, 'mask.fits'))[0].data
-
-    hdr = fits.PrimaryHDU().header
-    hdr.clear()
+    
     infilelist = glob.glob(infile)
-    if len(infilelist) == 0:
-        raise ValueError("No CHARIS file found for calibration.")
-
-    hdr['calfname'] = (re.sub('.*/', '', infilelist[0]),
-                       'Monochromatic image used for calibration')
-    try:
-        hdr['cal_date'] = (fits.open(infilelist[0])[0].header['mjd'],
-                           'MJD date of calibration image')
-    except:
-        hdr['cal_date'] = ('unavailable', 'MJD date of calibration image')
-    hdr['cal_lam'] = (lam, 'Wavelength of calibration image (nm)')
-    hdr['cal_band'] = (band, 'Band/mode of calibration image (J/H/K/lowres)')
-
-    ###############################################################
-    # Mean background count rate, weighted by inverse variance
-    ###############################################################
-
-    print('Computing ramps from sequences of raw reads')
-    num = 0
-    denom = 1e-100
-    ibg = 1
-    for filename in bgfiles:
-        bg = utr.calcramp(filename=filename, mask=mask, maxcpus=nthreads)
-        num = num + bg.data * bg.ivar
-        denom = denom + bg.ivar
-        hdr['bkgnd%03d' % (ibg)] = (re.sub('.*/', '', filename),
-                                    'Dark(s) used for background subtraction')
-        ibg += 1
-    if len(bgfiles) > 0:
-        background = Image(data=num / denom, ivar=1. / denom)
-        background.write('background.fits')
-    else:
-        hdr['bkgnd001'] = ('None', 'Dark(s) used for background subtraction')
-
-    ###############################################################
-    # Monochromatic flatfield image
-    ###############################################################
-
-    num = 0
-    denom = 1e-100
-    for filename in infilelist:
-        im = utr.calcramp(filename=filename, mask=mask, maxcpus=nthreads)
-        num = num + im.data * im.ivar
-        denom = denom + im.ivar
-    inImage = Image(data=num / denom, ivar=mask * 1. / denom)
-
-    trans = np.loadtxt(os.path.join(indir, band + '_tottrans.dat'))
-
-    buildcalibrations(inImage, lam, mask, indir, lam1=lam1, lam2=lam2,
-                      upsample=upsample, R=R, order=3, trans=trans,
-                      header=hdr, ncpus=nthreads)
-
-    out = fits.HDUList(fits.PrimaryHDU(None, hdr))
-    out.writeto('cal_params.fits', overwrite=True)
-
-    shutil.copy(os.path.join(indir, 'lensletflat.fits'), './lensletflat.fits')
-
-    for filename in ['mask.fits', 'pixelflat.fits']:
-        shutil.copy(os.path.join(indir, filename), './' + filename)
+    
+    # Calls main function
+    main(infilelist, bgfiles, band, lam, upsample, nthreads)

--- a/scripts/buildcal
+++ b/scripts/buildcal
@@ -306,6 +306,8 @@ def main(infilelist, bgfiles, band, lam, upsample, nthreads, outdir="./"):
     
     if not outdir.endswith('/') and outdir != '' :
         outdir += '/'
+    elif outdir == '':
+        outdir = './'
     
     ###############################################################
     # Wavelength limits in nm

--- a/scripts/extractcube
+++ b/scripts/extractcube
@@ -35,7 +35,7 @@ def getcube(filename, read_idx=[1, None], calibdir='calibrations/20160408/',
             method='lstsq', refine=True, suppressrn=True, fitshift=True,
             flatfield=True, smoothandmask=True,
             minpct=70, fitbkgnd=True, saveresid=False,
-            maxcpus=multiprocessing.cpu_count()):
+            maxcpus=multiprocessing.cpu_count(), outdir='./'):
     """Provisional routine getcube.  Construct and return a data cube
     from a set of reads.
 
@@ -77,6 +77,8 @@ def getcube(filename, read_idx=[1, None], calibdir='calibrations/20160408/',
     11. fitshift: Fit a subpixel shift in the psflet locations across
                  the detector?  Recommended except for quicklook.  Cost
                  is modest compared to cube extraction
+    12. outdir:  Path to the directory that any output files will be
+                 saved to.
 
     Returns:
     1. datacube: an instance of the Image class containing the data cube.
@@ -161,7 +163,7 @@ def getcube(filename, read_idx=[1, None], calibdir='calibrations/20160408/',
 
     header['bgsub'] = (bgsub, 'Subtract background count rate from a dark?')
     if saveramp:
-        inImage.write(re.sub('.*/', '', re.sub('.fits', '_ramp.fits', filename)))
+        inImage.write(re.sub('.*/', outdir, re.sub('.fits', '_ramp.fits', filename)))
 
     ################################################################
     # Read in necessary calibration files and extract the data cube.
@@ -235,7 +237,7 @@ def getcube(filename, read_idx=[1, None], calibdir='calibrations/20160408/',
                 maxcpus=maxcpus)
             if saveresid:
                 datacube, resid = result
-                resid.write(re.sub('.*/', '', re.sub('.fits', '_resid.fits', filename)))
+                resid.write(re.sub('.*/', outdir, re.sub('.fits', '_resid.fits', filename)))
             else:
                 datacube = result
 
@@ -316,7 +318,7 @@ if __name__ == "__main__":
     main( filenames, sys.argv[len(sys.argv) - 1] )
     
 
-def main( filenames, initfile):
+def main( filenames, initfile, outdir='./'):
     """
     Top-level task to run extractcube from the python environment. When called from the command line, passes input 
     (after parsing) to this function.
@@ -325,9 +327,15 @@ def main( filenames, initfile):
     1. filenames:   List of file paths and names to the observation
                     fits files to be extracted.
     2. initfile:    Path and name to the init file for extractcube.
+    
+    Optional inputs:
+    3. outdir:      Path to the directory where the output files 
+                    will be saved. Can be path from current working
+                    directory or full path. Default is to save in 
+                    current working directory.
         
 
-    Returns None, writes extracted cube files to working directory.
+    Returns None, writes extracted cube files to directory specified by outdir.
     
     If importing into Python for direct use or automation, recommend using pyximport (for Cython handling) and importing
     module via imp.load_source. Eg:
@@ -339,7 +347,8 @@ def main( filenames, initfile):
     >>> extractcube = imp.load_source('extractcube', '/path/to/charis-dep/scripts/extractcube' )
 
     """
-
+    if not outdir.endswith('/') and outdir != '':
+        outdir += '/'
     
     Config = ConfigParser.ConfigParser()
     Config.read(initfile)
@@ -423,5 +432,5 @@ def main( filenames, initfile):
                        smoothandmask=smoothandmask, flatfield=flatfield,
                        fitshift=fitshift, suppressrn=suppressrn,
                        minpct=minpct, fitbkgnd=fitbkgnd,
-                       saveresid=saveresid)
-        cube.write(re.sub('.fits', '_cube.fits', re.sub('.*/', '', filename)))
+                       saveresid=saveresid, outdir=outdir)
+        cube.write(re.sub('.fits', '_cube.fits', re.sub('.*/', outdir, filename)))

--- a/scripts/extractcube
+++ b/scripts/extractcube
@@ -312,9 +312,37 @@ if __name__ == "__main__":
 
     if len(filenames) == 0:
         raise ValueError("No matching CHARIS files found by extractcube.")
+    
+    main( filenames, sys.argv[len(sys.argv) - 1] )
+    
 
+def main( filenames, initfile):
+    """
+    Top-level task to run extractcube from the python environment. When called from the command line, passes input 
+    (after parsing) to this function.
+
+    Inputs:
+    1. filenames:   List of file paths and names to the observation
+                    fits files to be extracted.
+    2. initfile:    Path and name to the init file for extractcube.
+        
+
+    Returns None, writes extracted cube files to working directory.
+    
+    If importing into Python for direct use or automation, recommend using pyximport (for Cython handling) and importing
+    module via imp.load_source. Eg:
+    
+    >>> import pyximport
+    >>> pyximport.install(language_level=2)
+    (None, <pyximport.pyximport.PyxImporter object at 0x10bac3d50>)
+    >>> import imp
+    >>> extractcube = imp.load_source('extractcube', '/path/to/charis-dep/scripts/extractcube' )
+
+    """
+
+    
     Config = ConfigParser.ConfigParser()
-    Config.read(sys.argv[len(sys.argv) - 1])
+    Config.read(initfile)
 
     read_0 = Config.getint('Ramp', 'read_0')
     try:


### PR DESCRIPTION
Customizable output path for main extractcube

Follows edits from branch automate-extractcube

All edits are within scripts/extractcube. Added new optional 
parameter to extractcube.main, 'outdir', which specifies the 
directory path to save the output files in. All output is 
ported to this directory. Can either specify full path or 
path from current working directory. Default is to save files 
in the current working directory.

Also added outdir as optional parameter to extractcube.getcube,
with default again to output resid and ramp fits files to the
current working directory.
