### PR TITLE
Update calc_metadata.py

### DIFF
--- a/charis/utr/calc_metadata.py
+++ b/charis/utr/calc_metadata.py
@@ -7,6 +7,12 @@ from astropy import units as u
 from astropy.io import fits
 from astropy.time import Time
 
+from astropy.utils import iers    #importing iers to pull The International Earth Rotation and Reference Systems Service data for WCS/PA determination
+iers.Conf.iers_auto_url.set('https://datacenter.iers.org/data/9/finals2000A.all') #force astropy to point here
+
+#possible work-around of ssl certificate problems with iers
+#import ssl
+#ssl._create_default_https_context = ssl._create_unverified_context  
 
 def _fetch(key, filename, comment=None, newkey=None):
     """


### PR DESCRIPTION
- partial fix of parallactic angle/WCS determination to point to the correct URL. 

-   Suggested workaround of ssl certificate errors is commented out.   We frequently get SSL timeouts due to certificate errors.   iers works fine in Python3 but for at least some versions of astropy.iers in Python2 (e.g. mine), you get certificate timeout errors: 
"<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed"

The workaround I "think" is to trick astropy into not requiring a certificate for download.   I was able to get a manual update to finalsA.2000 this way in Python2 interactive mode: see the SCExAO/software and charis-users/charis-drp Slack channels for details.