### PR TITLE
Fix missing HDU in CHARIS extraction

### DIFF
--- a/charis/image/image.py
+++ b/charis/image/image.py
@@ -147,13 +147,13 @@ class Image(object):
             out.append(fits.PrimaryHDU(self.chisq.astype('float32'), hdr))
         if self.flags is not None:
             out.append(fits.PrimaryHDU(self.flags), hdr)
-        # if self.extraheader is not None:
-        #    try:
-        #        extra_hdr = fits.PrimaryHDU(None, self.extraheader)
-        #        extra_hdr.verify('fix')
-        #        out.append(extra_hdr)
-        #    except Exception:
-        #        log.warn("Failed to attach extra header.")
+        if self.extraheader is not None:
+           try:
+               extra_hdr = fits.PrimaryHDU(None, self.extraheader)
+               extra_hdr.verify('fix')
+               out.append(extra_hdr)
+           except Exception:
+               log.warn("Failed to attach extra header.")
 
         # try:
 


### PR DESCRIPTION
The following block of code was commented out back in October of 2018 (cc @m-samland). This causes downstream problems in the CHARIS-DPP which requires values from the original FITS headers of CHARIS, such as the half-wave plate angle. I've uncommented this block and I have no troubles extracting CHARIS data taken on 2023/01/01.